### PR TITLE
Allow <blockquote> tag in item content.

### DIFF
--- a/CRM/Newsstore/Rss.php
+++ b/CRM/Newsstore/Rss.php
@@ -4,7 +4,7 @@
  */
 class CRM_Newsstore_Rss extends CRM_Newsstore
 {
-  const PERMITTED_HTML_TAGS= '<br><p><h1><h2><h3><h4><h5><h6><ul><ol><li><dd><dt><dl><hr><embed><object><a><div><table><thead><tbody><tr><th><td><strong><em><b><i><img>';
+  const PERMITTED_HTML_TAGS= '<br><p><h1><h2><h3><h4><h5><h6><ul><ol><li><dd><dt><dl><hr><embed><object><a><div><table><thead><tbody><tr><th><td><strong><em><b><i><img><blockquote>';
   /**
    * Namespaces cache.
    */


### PR DESCRIPTION
This is meant to solve the immediate need in #8 by allowing `<blockquote>`. But it does not attempt to "Allow configuration of PERMITTED_HTML_TAGS" as in the title of that issue.